### PR TITLE
Syntax von Funkwellensymbol repariert

### DIFF
--- a/symbols/Fernmeldewesen/Digitaler_Sprechfunk.j2
+++ b/symbols/Fernmeldewesen/Digitaler_Sprechfunk.j2
@@ -2,5 +2,5 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
 	<path d="M10,58 l90,0 l0,56 l56,0 l0,-56 l90,0" stroke="#000000" stroke-width="5" fill="none" />
 	<path d="M10,128 l236,0" stroke="#000000" stroke-width="5" fill="none" />
-	<path d="M38,138 l30,30 l30,-30 l30,30 l30,-30 l30,30, l30,-30" stroke="#000000" stroke-width="5" fill="none" />
+	<path d="M38,138 l30,30 l30,-30 l30,30 l30,-30 l30,30 l30,-30" stroke="#000000" stroke-width="5" fill="none" />
 </svg>

--- a/symbols/Fernmeldewesen/Fernsprechen_über_Funk.j2
+++ b/symbols/Fernmeldewesen/Fernsprechen_über_Funk.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
 	<path d="M10,128 l236,0" stroke="#000000" stroke-width="5" fill="none" />
-	<path d="M38,138 l30,30 l30,-30 l30,30 l30,-30 l30,30, l30,-30" stroke="#000000" stroke-width="5" fill="none" />
+	<path d="M38,138 l30,30 l30,-30 l30,30 l30,-30 l30,30 l30,-30" stroke="#000000" stroke-width="5" fill="none" />
 </svg>

--- a/symbols/Fernmeldewesen/Relaisfunkbetrieb.j2
+++ b/symbols/Fernmeldewesen/Relaisfunkbetrieb.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
 	<path d="M10,128 l236,0" stroke="#000000" stroke-width="5" fill="none" />
-	<path d="M32,178 a20,20 0 0,0 0,-40 M50,150 l18,18 l30,-30 l30,30 l30,-30 l30,30, l17,-17 M224,178 a20,20 0 0,1 0,-40" stroke="#000000" stroke-width="5" fill="none" />
+	<path d="M32,178 a20,20 0 0,0 0,-40 M50,150 l18,18 l30,-30 l30,30 l30,-30 l30,30 l17,-17 M224,178 a20,20 0 0,1 0,-40" stroke="#000000" stroke-width="5" fill="none" />
 </svg>


### PR DESCRIPTION
Hier war ein Komma zu viel, was ein falsches Rendering in Firefox verursacht hat.

Übrigens wollte mein Emacs unbedingt ein Newline am Ende der Datei, was auch eigentlich üblich ist. Ich habs nochmal weggemacht, weil ich kein Durcheinander machen wollte. Gibt's einen Grund, das die Datein hier alle kein Newline haben?