### PR TITLE
THW Einheiten mit StAN 2020 abgeglichen

### DIFF
--- a/symbols/THW_Einheiten/FGr_FK_Weitverkehrstrupp.j2
+++ b/symbols/THW_Einheiten/FGr_FK_Weitverkehrstrupp.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#FFFFFF" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">WV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/FGr_Ortung_biologisch.j2
+++ b/symbols/THW_Einheiten/FGr_Ortung_biologisch.j2
@@ -13,6 +13,6 @@
 	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
 	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">O</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/FGr_Ortung_biologisch_und_technisch.j2
+++ b/symbols/THW_Einheiten/FGr_Ortung_biologisch_und_technisch.j2
@@ -13,6 +13,6 @@
 	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
 	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">O</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/FGr_Ortung_technisch.j2
+++ b/symbols/THW_Einheiten/FGr_Ortung_technisch.j2
@@ -13,6 +13,6 @@
 	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
 	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">O</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/Grundausbildungsgruppe.j2
+++ b/symbols/THW_Einheiten/Grundausbildungsgruppe.j2
@@ -10,6 +10,6 @@
 	</defs>
 	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
 	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">GAGR</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">GAGr</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/Jugendgruppe.j2
+++ b/symbols/THW_Einheiten/Jugendgruppe.j2
@@ -10,6 +10,6 @@
 	</defs>
 	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
 	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">JuGR</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">JuGr</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/OV_Stab.j2
+++ b/symbols/THW_Einheiten/OV_Stab.j2
@@ -10,6 +10,7 @@
 	</defs>
 	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
 	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#FFFFFF" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">OV Stab</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Brückenbau.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Brückenbau.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-BrB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Elektroversorgung.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Elektroversorgung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-E</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_A.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_B.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_C.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ortung_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_A.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_B.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_C.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Räumen_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Sprengen.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Sprengen.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-Sp</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wassergefahren_A.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wassergefahren_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wassergefahren_B.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wassergefahren_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_A.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_B.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_C.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_A.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_B.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_C.j2
+++ b/symbols/THW_Einheiten/Technischer_Zug_mit_FGr_Ölschaden_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256">
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#003399" stroke="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 300%; dominant-baseline: central;" fill="#FFFFFF" x="128" y="128">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+</svg>


### PR DESCRIPTION
 * Typen der FGr O haben nicht mit der StAN übereingestimmt --> ggf. sollte wie bei den anderen FGr auch hier einfach nur A, B und C hinter dem Namen stehen
 * Beim OV das r am Ende der Gruppen klein und der OV Stab hat oben einen weißen Balken
 * FGr FK WV Tr gemäß StAN angelegt (nur WV und Balken oben), den alten mit dem Fm Symbol habe ich aber drin gelassen
 * fehlende TZ-* erstell und auch Sybole für die Typen