### PR TITLE
Fernmeldewesen - Satellitentelefon, IP-Telfon, Anpassungen

### DIFF
--- a/symbols/Fernmeldewesen/Fahrzeugfunkgerät_digital.j2
+++ b/symbols/Fernmeldewesen/Fahrzeugfunkgerät_digital.j2
@@ -6,6 +6,7 @@
 		</style>
 	</defs>
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
-	<path d="M80,94 l98,0" stroke-width="5" stroke="#000000" fill="none" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="160">MRT</text>
+	<path d="M80,74 l96,0" stroke-width="5" stroke="#000000" fill="none" />
+	<path d="M80,84 l16,16 l16,-16 l16,16 l16,-16 l16,16 l16,-16" stroke="#000000" stroke-width="5" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="142">MRT</text>
 </svg>

--- a/symbols/Fernmeldewesen/Funk_Feststation_digital.j2
+++ b/symbols/Fernmeldewesen/Funk_Feststation_digital.j2
@@ -6,6 +6,7 @@
 		</style>
 	</defs>
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
-	<path d="M80,94 l98,0" stroke-width="5" stroke="#000000" fill="none" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="160">FRT</text>
+	<path d="M80,74 l96,0" stroke-width="5" stroke="#000000" fill="none" />
+	<path d="M80,84 l16,16 l16,-16 l16,16 l16,-16 l16,16 l16,-16" stroke="#000000" stroke-width="5" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="142">FRT</text>
 </svg>

--- a/symbols/Fernmeldewesen/Handfunkgerät_digital.j2
+++ b/symbols/Fernmeldewesen/Handfunkgerät_digital.j2
@@ -6,6 +6,7 @@
 		</style>
 	</defs>
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
-	<path d="M80,94 l98,0" stroke-width="5" stroke="#000000" fill="none" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="160">HRT</text>
+	<path d="M80,74 l96,0" stroke-width="5" stroke="#000000" fill="none" />
+	<path d="M80,84 l16,16 l16,-16 l16,16 l16,-16 l16,16 l16,-16" stroke="#000000" stroke-width="5" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 40px; text-anchor: middle;" fill="#000000" x="128" y="142">HRT</text>
 </svg>

--- a/symbols/Fernmeldewesen/Kofferfunkgerät_digital.j2
+++ b/symbols/Fernmeldewesen/Kofferfunkgerät_digital.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,74 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<path d="M80,84 l16,16 l16,-16 l16,16 l16,-16 l16,16 l16,-16" stroke="#000000" stroke-width="5" fill="none" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="145">MRT-K</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="140">MRT-K</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_AWITEL.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_AWITEL.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,84 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" fill="#000000" x="128" y="145">W</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 24px; text-anchor: middle;" fill="#000000" x="128" y="172">AWITEL</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 24px; text-anchor: middle;" fill="#000000" x="128" y="180">AWITEL</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_IP.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_IP.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,84 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" fill="#000000" x="128" y="145">W</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">POTS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">IP</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_ISDN.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_ISDN.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,84 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" fill="#000000" x="128" y="145">W</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="172">ISDN</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">ISDN</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_Satellit.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_Satellit.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,84 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" fill="#000000" x="128" y="145">W</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">POTS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">SAT</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_Up0.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_Up0.j2
@@ -8,5 +8,5 @@
 	<rect x="64" y="64" width="128" height="128" stroke-width="5" stroke="#000000" fill="#FFFFFF" />
 	<path d="M80,84 l96,0" stroke-width="5" stroke="#000000" fill="none" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 48px; text-anchor: middle;" fill="#000000" x="128" y="145">W</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="172">Up0</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; font-size: 32px; text-anchor: middle;" fill="#000000" x="128" y="180">Up0</text>
 </svg>

--- a/symbols/Fernmeldewesen/Wähltelefon_analog.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_analog.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256" viewbox="0 0 256 256>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
 	<defs>
 		<style type="text/css">
 		{% include './fonts/fonts.j2' %}

--- a/symbols/Fernmeldewesen/Wähltelefon_analog.j2
+++ b/symbols/Fernmeldewesen/Wähltelefon_analog.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256" viewbox="0 0 256 256>
 	<defs>
 		<style type="text/css">
 		{% include './fonts/fonts.j2' %}


### PR DESCRIPTION
Höhe des Zusatztextes einheitlich angepasst, bei den Digitalfunkgeräten die Schrift auf dieselbe Höhe wie bei den anderen Geräten gebracht und Bedingszeichen vereinheitlicht.