### PR TITLE
Text nach oben aus Logistikbalken heraus verschoben

### DIFF
--- a/symbols/THW_Einheiten/Fachzug_Logistik.j2
+++ b/symbols/THW_Einheiten/Fachzug_Logistik.j2
@@ -15,6 +15,6 @@
 	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
 	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
 	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="145">FZ-Log</text>
-	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="180">THW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="128">FZ-Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#FFFFFF" x="236" y="160">THW</text>
 </svg>


### PR DESCRIPTION
"THW" ist in den Logistikbalken gerutscht, gefixed