### PR TITLE
Alle Zeichen des THW in invertierter Farbgebung

### DIFF
--- a/symbols/THW_Einheiten_weiß/1._Bergungsgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/1._Bergungsgruppe.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>1. Bergungsgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 1</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/1._Bergungsgruppe_ASH.j2
+++ b/symbols/THW_Einheiten_weiß/1._Bergungsgruppe_ASH.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>1. Bergungsgruppe mit Abstützsystem Holz</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 1</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">ASH</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/1._Bergungsgruppe_EGS.j2
+++ b/symbols/THW_Einheiten_weiß/1._Bergungsgruppe_EGS.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>1. Bergungsgruppe mit Einsatzgerüstsystem</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 1</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">EGS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/2._Bergungsgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/2._Bergungsgruppe.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>2. Bergungsgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 2</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/2._Bergungsgruppe_A.j2
+++ b/symbols/THW_Einheiten_weiß/2._Bergungsgruppe_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>2. Bergungsgruppe Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 2</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/2._Bergungsgruppe_B.j2
+++ b/symbols/THW_Einheiten_weiß/2._Bergungsgruppe_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>2. Bergungsgruppe Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B 2</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Alters_und_Ehrengruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Alters_und_Ehrengruppe.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Alters- und Ehrengruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">AEGr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/BR_Stab.j2
+++ b/symbols/THW_Einheiten_weiß/BR_Stab.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Bereitstellungsraum Stab</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stab</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Bergungsgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Bergungsgruppe.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Bergungsgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Bergungsgruppe_ASH.j2
+++ b/symbols/THW_Einheiten_weiß/Bergungsgruppe_ASH.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Bergungsgruppe mit Abstützsystem Holz</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">ASH</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Bergungsgruppe_EGS.j2
+++ b/symbols/THW_Einheiten_weiß/Bergungsgruppe_EGS.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>1. Bergungsgruppe mit Einsatzgerüstsystem</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">EGS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/ENT.j2
+++ b/symbols/THW_Einheiten_weiß/ENT.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Einsatznachsorge-Team</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">ENT</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Beleuchtung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Beleuchtung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Beleuchtung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Bel</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Beleuchtung_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Beleuchtung_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Beleuchtung Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Bel</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Beleuchtung_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Beleuchtung_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Beleuchtung Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Bel</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Brückenbau.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Brückenbau.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Brückenbau</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">BrB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Brückenbau_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Brückenbau_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Brückenbau Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">BrB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Brückenbau_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Brückenbau_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Brückenbau Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">BrB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Elektroversorgung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Elektroversorgung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Elektroversorgung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">E</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Fachgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Fachgruppe.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FGr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FK</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FK</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FK</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Fernmeldetrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Fernmeldetrupp.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation - Fernmeldetrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Fm</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Führungs_und_Kommunikationstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Führungs_und_Kommunikationstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation - Führungs und Kommunikationstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FüKom</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Führungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Führungstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation - Führungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Fü</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Weitverkehrstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führung-Kommunikation_Weitverkehrstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führung-Kommunikation - Weitverkehrstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Führungsunterstützung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Führungsunterstützung.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Führungsunterstützung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">F</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Infrastruktur.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Infrastruktur.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Infrastruktur</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">I</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Kommunikation_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Kommunikation_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Kommunikation Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">K</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Kommunikation_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Kommunikation_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Kommunikation Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">K</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik-Verpflegung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik-Verpflegung.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik-Verpflegung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log-V</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik_Führungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik_Führungstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik - Führungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialerhaltungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialerhaltungstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik - Materialerhaltungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log-M</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialwirtschaft.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialwirtschaft.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik-Materialwirtschaft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log-MW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialwirtschaft_Verbrauchsgüterversorgungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik_Materialwirtschaft_Verbrauchsgüterversorgungstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik-Materialwirtschaft - Verbrauchsgüterversorgungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log-VG</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Logistik_Versorgungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Logistik_Versorgungstrupp.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Logistik - Versorgungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log-V</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Notversorgung_und_Notinstandsetzung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Notversorgung_und_Notinstandsetzung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Notversorgung und Notinstandsetzung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">N</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ortung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ortung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ortung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ortung_biologisch.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ortung_biologisch.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ortung - Biologisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ortung_biologisch_und_technisch.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ortung_biologisch_und_technisch.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ortung - Biologisch und Technisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ortung_technisch.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ortung_technisch.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ortung - Technisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen_A_Bagger.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen_A_Bagger.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen Typ A (Bagger)</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A (B)</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen_A_Radlader.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen_A_Radlader.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen Typ A (Radlader)</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A (R)</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Räumen_C.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Räumen_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Räumen Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Schwere Bergung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Schwere Bergung Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Schwere_Bergung_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Schwere Bergung Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Sprengen.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Sprengen.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Sprengen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Sp</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Trinkwasser.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Trinkwasser.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Trinkwasser</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Trinkwasser_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Trinkwasser_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Trinkwasser Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Trinkwasser_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Trinkwasser_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Trinkwasser Type B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassergefahren.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassergefahren.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wassergefahren</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassergefahren_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassergefahren_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wassergefahren Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassergefahren_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassergefahren_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wassergefahren Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wasserschaden-Pumpen.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wasserschaden-Pumpen.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wasserschaden-Pumpen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wasserschaden-Pumpen Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wasserschaden-Pumpen Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_C.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Wassserschaden-Pumpen_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Wasserschaden-Pumpen Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ölschaden.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ölschaden.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ölschaden</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ölschaden_A.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ölschaden_A.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ölschaden Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ölschaden_B.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ölschaden_B.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ölschaden Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/FGr_Ölschaden_C.j2
+++ b/symbols/THW_Einheiten_weiß/FGr_Ölschaden_C.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachgruppe Ölschaden Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Fachzug_Führung_Kommunikation.j2
+++ b/symbols/THW_Einheiten_weiß/Fachzug_Führung_Kommunikation.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachzug Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FZ-FK</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Fachzug_Logistik.j2
+++ b/symbols/THW_Einheiten_weiß/Fachzug_Logistik.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachzug Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FZ-Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Führungseinheit.j2
+++ b/symbols/THW_Einheiten_weiß/Führungseinheit.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Führungseinheit</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Führungstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/Führungstrupp.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Führungstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Grundausbildungsgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Grundausbildungsgruppe.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Grundausbildungsgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">GAGr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Gruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Gruppe.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Jugendgruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Jugendgruppe.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Jugendgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">JuGr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Logistikeinheit.j2
+++ b/symbols/THW_Einheiten_weiß/Logistikeinheit.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Logistikeinheit</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Logistiktrupp.j2
+++ b/symbols/THW_Einheiten_weiß/Logistiktrupp.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Logistiktrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Lotsengruppe.j2
+++ b/symbols/THW_Einheiten_weiß/Lotsengruppe.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Lotsengruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">L</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/OV_Stab.j2
+++ b/symbols/THW_Einheiten_weiß/OV_Stab.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>OV Stab</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">OV Stab</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/SEEBA.j2
+++ b/symbols/THW_Einheiten_weiß/SEEBA.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Schnelleinsatzeinheit Bergung Ausland</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SEEBA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/SEELift.j2
+++ b/symbols/THW_Einheiten_weiß/SEELift.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Schnelleinsatzeinheit Logistikabwicklung im Lufttransportfall</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SEELift</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/SEEWA.j2
+++ b/symbols/THW_Einheiten_weiß/SEEWA.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Schnelleinsatzeinheit Wasser Ausland</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SEEWA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Stab.j2
+++ b/symbols/THW_Einheiten_weiß/Stab.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Stab</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="65" width="234" height="25" fill="#003399" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stab</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Staffel.j2
+++ b/symbols/THW_Einheiten_weiß/Staffel.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Staffel</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="24" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/SysBR.j2
+++ b/symbols/THW_Einheiten_weiß/SysBR.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>System Bereitstellungsraum</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SysBR</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/THV_Bereitschaft.j2
+++ b/symbols/THW_Einheiten_weiß/THV_Bereitschaft.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technische Hilfe auf Verkehrswegen - Bereitschaft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">THV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Brückenbau.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Brückenbau.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Brückenbau</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-BrB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Elektroversorgung.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Elektroversorgung.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Elektroversorgung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-E</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Infrastruktur.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Infrastruktur.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Infrastruktur</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-I</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ortung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_A.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_A.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ortung - Biologisch und Technisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_B.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_B.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ortung - Biologisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_C.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ortung_C.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ortung - Technisch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-O</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Räumen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_A.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_A.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Räumen Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_B.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_B.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Räumen Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_C.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Räumen_C.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Räumen Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-R</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Sprengen.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Sprengen.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Sprengen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-Sp</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Trinkwasser.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Trinkwasser.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Trinkwasser</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-TW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wassergefahren</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren_A.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren_A.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wassergefahren Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren_B.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wassergefahren_B.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wassergefahren Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-W</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wasserschaden-Pumpen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_A.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_A.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wasserschaden-Pumpen Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_B.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_B.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wasserschaden-Pumpen Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_C.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Wasserschaden_Pumpen_C.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Wasserschaden-Pumpen Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-WP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ölschaden</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_A.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_A.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ölschaden Typ A</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_B.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_B.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ölschaden Typ B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_C.j2
+++ b/symbols/THW_Einheiten_weiß/Technischer_Zug_mit_FGr_Ölschaden_C.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Technischer Zug mit Fachgruppe Ölschaden Typ C</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ-Öl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">C</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Trupp.j2
+++ b/symbols/THW_Einheiten_weiß/Trupp.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Trupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Trupp_ESS.j2
+++ b/symbols/THW_Einheiten_weiß/Trupp_ESS.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Trupp Einsatzstellen-Sicherungssystem</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">ESS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Trupp_MHP.j2
+++ b/symbols/THW_Einheiten_weiß/Trupp_MHP.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Trupp Mobiler Hochwasserpegel</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MHP</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Trupp_TS.j2
+++ b/symbols/THW_Einheiten_weiß/Trupp_TS.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Trupp Schwerer Transport</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Trupp_UL.j2
+++ b/symbols/THW_Einheiten_weiß/Trupp_UL.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Trupp Unbemannte Luftfahrzeuge</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">UL</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/VOST.j2
+++ b/symbols/THW_Einheiten_weiß/VOST.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Virtual Operations Support Team</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">VOST</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Verband_Feldlager.j2
+++ b/symbols/THW_Einheiten_weiß/Verband_Feldlager.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Verband Feldlager</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+
+	<line x1="128" y1="64" x2="128" y2="28" stroke="#000000" stroke-width="10" />
+
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FLgr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Verband_Logistik.j2
+++ b/symbols/THW_Einheiten_weiß/Verband_Logistik.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Verband Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<rect x="11" y="166" width="234" height="25" fill="#003399" />
+	
+	<line x1="128" y1="64" x2="128" y2="28" stroke="#000000" stroke-width="10" />
+
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399" x="128" y="128">Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="160">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Weitverkehrstrupp.j2
+++ b/symbols/THW_Einheiten_weiß/Weitverkehrstrupp.j2
@@ -1,0 +1,24 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Weitverkehrstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+		<mask id="ends">
+			<rect width="100%" height="100%" fill="#FFFFFF" />
+			<path d="M50 160 a16 16 0 0 0 0 -32" stroke="#000000" />
+			<path d="M206 160 a16 16 0 0 1 0 -32" stroke="#000000" />
+		</mask>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#FFFFFF" x="128" y="120">WV</text>
+	<path d="M50 160 a16 16 0 0 0 0 -32 M206 160 a16 16 0 0 1 0 -32" stroke="#FFFFFF" stroke-width="5" fill="none" />
+	<path d="M56 132 l24 24 l24 -24 l24 24 l24 -24 l24 24 l24 -24" stroke="#FFFFFF" stroke-width="5" fill="none" mask="url(#ends)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Zug.j2
+++ b/symbols/THW_Einheiten_weiß/Zug.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zug</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Zugtrupp.j2
+++ b/symbols/THW_Einheiten_weiß/Zugtrupp.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="64"  cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="128" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="192" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TZ</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Zugtrupp_FZ-FK.j2
+++ b/symbols/THW_Einheiten_weiß/Zugtrupp_FZ-FK.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtrupp Fachzug Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="64"  cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="128" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="192" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FZ-FK</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Zugtrupp_FZ-Logistik.j2
+++ b/symbols/THW_Einheiten_weiß/Zugtrupp_FZ-Logistik.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtrupp Fachzug Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="128" cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="64"  cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="128" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<ellipse cx="192" cy="86" rx="10" ry="10" fill="#FFFFFF" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FZ-Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Einheiten_weiß/Örtliche_Gefahrenabwehr.j2
+++ b/symbols/THW_Einheiten_weiß/Örtliche_Gefahrenabwehr.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Örtliche Gefahrenabwehr</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<rect x="10" y="64" width="236" height="128" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<rect x="10" y="64" width="236" height="128" fill="none" stroke="#000000" stroke-width="1" />
+	<ellipse cx="64"  cy="48" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="192" cy="48" rx="10" ry="10" fill="#000000" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">ÖGA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Abrollbehälter_Container.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Abrollbehälter_Container.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Abrollbehälter Container</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+		<clipPath id="hook">
+			<rect x="0" y="44" width="10" height="148" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_0_5t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_0_5t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger 0,5t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">0,5 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_2t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger 2t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_6t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_6t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger 6t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">6 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_7t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_7t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger 7t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">7 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_DLE.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_DLE.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Drucklufterzeugung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">DLE</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_FKH.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_FKH.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Feldkochherd</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FKH</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_FüLa.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_FüLa.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Führung und Lage</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FüLa</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_I_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_I_2t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Infrastruktur 2t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">I 2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_K_1t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_K_1t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger K 1t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">K 1 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Kühl.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Kühl.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kühlanhänger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Kühl</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg> 

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Lichtmast.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Lichtmast.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger mit Lichtmast</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LiMa</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Log-MW_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Log-MW_2t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Logistik-Materialwirtschaft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px; " fill="#FFFFFF" x="128" y="145">Log-MW 2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_MzAB.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_MzAB.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Mehrzweckarbeitsboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MzAB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_MzB.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_MzB.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Mehrzweckboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MzB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_MzPt.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_MzPt.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Mehrzweckponton</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MzPt</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_200kVA.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_200kVA.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Netzersatzanlage 200 kVA</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">NEA</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">200 kVA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_50kVA_LiMa.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_50kVA_LiMa.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Netzersatzanlage 50 kVA mit Lichtmast</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">NEA</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">50 kVA LiMa</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_650kVA.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_NEA_650kVA.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Netzersatzanlage 650 kVA</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">NEA</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">650 kVA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Netzersatzanlage.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Netzersatzanlage.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Netzersatzanlage</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">NEA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_O_A_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_O_A_2t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Ortung 2 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O 2 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">A</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_O_B_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_O_B_2t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger biologische Ortung 2 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">O 2 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">B</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_PF_12t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_PF_12t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Plattformanhänger 12 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">PF 12 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Rettungshunde.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Rettungshunde.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Rettungshunde</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">RettH</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_RiFu.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_RiFu.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Richtfunk</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">RiFu</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Ru12t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Ru12t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Rungen 12 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Ru 12 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_SchlB.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_SchlB.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Schlauchboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SchlB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Sp_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Sp_2t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Sprengen 2 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Sp 2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Spül.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Spül.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Spülanhänger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Spül</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Stromerzeuger.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Stromerzeuger.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Stromerzeuger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SEA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_15000.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_15000.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Schmutzwasserpumpe 15.000 l/min</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SwPu</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">15.000 l/min</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_25000.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_25000.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Schmutzwasserpumpe 25.000 l/min</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SwPu</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">25.000 l/min</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_5000.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_SwPu_5000.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Schmutzwasserpumpe 5000 l/min</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SwPu</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">5.000 l/min</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_TWAA.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_TWAA.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Trinkwasseraufbereitungsanlage</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">TWAA</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Tieflader_18t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Tieflader_18t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger Tieflader 18 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Tiefl 18 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_Werkstatt.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_Werkstatt.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Werkstattanhänger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Wks</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Anhänger_kl_Boot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Anhänger_kl_Boot.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Anhänger kleines Boot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<rect x="0" y="121.5" width="11" height="15" fill="#FFFFFF" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="#000000" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">kl Boot</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Bergungsräumgerät.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Bergungsräumgerät.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Bergungsräumgerät</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">BRmG</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Boot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Boot.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Boot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/ERS.j2
+++ b/symbols/THW_Fahrzeuge_weiß/ERS.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Einsatz-Rettungs-Spinne</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">ERS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/FmKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/FmKW.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fernmeldekraftwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FmKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/FüKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/FüKW.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Führungskraftwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">FüKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/FüKomKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/FüKomKW.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Führungs- und Kommunikationskraftwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 37px; " fill="#FFFFFF" x="128" y="145">FüKomKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/GKW_7t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/GKW_7t.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gerätekraftwagen 7 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">GKW 7 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/GKW_I.j2
+++ b/symbols/THW_Fahrzeuge_weiß/GKW_I.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gerätekraftwagen I</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">GKW I</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/GKW_II.j2
+++ b/symbols/THW_Fahrzeuge_weiß/GKW_II.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gerätekraftwagen II</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">GKW II</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Gabelstapler.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Gabelstapler.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gabelstapler</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stapler</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Gabelstapler_2t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Gabelstapler_2t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gabelstapler 2 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stapler</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Gabelstapler_3t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Gabelstapler_3t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gabelstapler 3 t </title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stapler</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">3 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Geländestapler.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Geländestapler.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Geländestapler</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+    <ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Stapler</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Kettenbagger.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Kettenbagger.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kettenbagger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<path d="M24,200 l208,0 a10,10 180 0 1 0,20 l-208,0 a10,10 180 0 1 0,-20 Z" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Bagger</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Kettenfahrzeug.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Kettenfahrzeug.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kettenfahrzeug</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<path d="M24,200 l208,0 a10,10 180 0 1 0,20 l-208,0 a10,10 180 0 1 0,-20 Z" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Kipper.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Kipper.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kipper</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Kipper</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Kraftfahrzeug.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Kraftfahrzeug.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kraftfahrzeug</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Kraftfahrzeug_Geländegängig.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Kraftfahrzeug_Geländegängig.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kraftfahrzeug geländegängig</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW-Ladekran.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW-Ladekran.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW mit Ladekran</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-Lkr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW_K_9t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW_K_9t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW Kipper 9 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-K</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">9 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW_K_Lkr.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW_K_Lkr.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW Kipper mit Ladekran</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-K</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">LKr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW_K_Lkr_1_5t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW_K_Lkr_1_5t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW Kipper mit Ladekran 1,5 t </title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-K</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">LKr 1,5 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW_Lbw.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW_Lbw.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW mit Ladebordwand</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-Lbw</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/LKW_Lbw_7t.j2
+++ b/symbols/THW_Fahrzeuge_weiß/LKW_Lbw_7t.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>LKW mit Ladebordwand 7 t</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">LKW-Lbw</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">7 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MLW_I.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MLW_I.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftslastwagen I</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MLW I</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MLW_II.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MLW_II.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftslastwagen II</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MLW II</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MLW_III.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MLW_III.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftslastwagen III</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MLW III</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MLW_IV.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MLW_IV.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftslastwagen IV</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MLW IV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MLW_V.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MLW_V.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftslastwagen V</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MLW V</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MTW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MTW.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftstransportwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MTW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MTW_FGr.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MTW_FGr.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mannschaftstransportwagen Fachgruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MTW FGr</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Mehrzweckarbeitsboot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Mehrzweckarbeitsboot.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mehrzweckarbeitsboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">MzAB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Mehrzweckboot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Mehrzweckboot.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mehrzweckboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">MzB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Mehrzweckponton.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Mehrzweckponton.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mehrzweckponton</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">MzPt</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MzGW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MzGW.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mehrzweckgerätewagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MzGW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/MzKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/MzKW.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Mehrzweckkraftwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">MzKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/PKW.j2
+++ b/symbols/THW_Fahrzeuge_weiß/PKW.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Personenkraftwagen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">PKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/PKW_Geländegängig.j2
+++ b/symbols/THW_Fahrzeuge_weiß/PKW_Geländegängig.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Personenkraftwagen geländegängig</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">PKW</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/PKW_Weitverkehrstrupp.j2
+++ b/symbols/THW_Fahrzeuge_weiß/PKW_Weitverkehrstrupp.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Personenkraftwagen Weitverkehrstrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">PKW WV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Radbagger.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Radbagger.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Radbagger</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Bagger</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Radlader.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Radlader.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Radlader</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Radlader</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Rettungs_und_Sicherungsboot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Rettungs_und_Sicherungsboot.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Rettungs- und Sicherungsboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">RuSB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Sattelzugmaschine.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Sattelzugmaschine.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sattelzugmaschine</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5"  />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">SZM</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Schlauchboot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Schlauchboot.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Schlauchboot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">SchlB</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/THV.j2
+++ b/symbols/THW_Fahrzeuge_weiß/THV.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fahrzeug für Technische Hilfe auf Verkehrswegen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">THV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Teleskoplader.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Teleskoplader.j2
@@ -1,0 +1,19 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Teleskoplader</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Telelader</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start;" fill="#FFFFFF" x="20" y="180">2 t</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Wechselladerfahrzeug.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Wechselladerfahrzeug.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Wechselladerfahrzeug</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5" />
+	<ellipse cx="128" cy="209" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5"  />
+	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="#000000" fill="none" stroke-width="5"  />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">WLF</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/Werkstattcontainer.j2
+++ b/symbols/THW_Fahrzeuge_weiß/Werkstattcontainer.j2
@@ -1,0 +1,20 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Werkstattcontainer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+		<clipPath id="hook">
+			<rect x="0" y="44" width="10" height="148" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="#FFFFFF" stroke-width="10" stroke="#003399" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="#000000" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#003399" x="128" y="145">Wks</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge_weiß/kleines_Boot.j2
+++ b/symbols/THW_Fahrzeuge_weiß/kleines_Boot.j2
@@ -1,0 +1,16 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kleines Boot</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#003399" fill="#FFFFFF" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10,64 l236,0 A118,118 180 0 1 10,64 Z" stroke="#000000" fill="none" stroke-width="1" clip-path="url(#symbol)" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="#FFFFFF" x="128" y="127">kl Boot</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#000000" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/Ausbildungszentrum.j2
+++ b/symbols/THW_Gebäude_weiß/Ausbildungszentrum.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Ausbildungszentrum</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">AZ</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/Landesverband.j2
+++ b/symbols/THW_Gebäude_weiß/Landesverband.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Landesverband</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">LV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/Leitung.j2
+++ b/symbols/THW_Gebäude_weiß/Leitung.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Leitung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">Ltg</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/Logistikzentrum.j2
+++ b/symbols/THW_Gebäude_weiß/Logistikzentrum.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Logistikzentrum</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">Log</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/OV_Unterkunft.j2
+++ b/symbols/THW_Gebäude_weiß/OV_Unterkunft.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>OV Unterkunft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">OV</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Gebäude_weiß/Regionalstelle.j2
+++ b/symbols/THW_Gebäude_weiß/Regionalstelle.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Regionalstelle</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64 Z" />
+		</clipPath>
+	</defs>
+	<rect x="10" y="64" width="236" height="128" fill="#FFFFFF" stroke="#003399" stroke-width="10" clip-path="url(#symbol)" />
+	<path d="M10 64 L128 16 L246 64" stroke="#003399" stroke-width="10" fill="#FFFFFF" clip-path="url(#symbol)" />
+	<path d="M10 64 L10 192 L246 192 L246 64 L128 16 L10 64" stroke="#000000" stroke-width="1" fill="none" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 80px;" fill="#003399" x="128" y="155">RSt</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end;" fill="#003399" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Abschnittsleiter_THW.j2
+++ b/symbols/THW_Personen_weiß/Abschnittsleiter_THW.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Abschnittsleiter THW</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">THW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Baufachberater.j2
+++ b/symbols/THW_Personen_weiß/Baufachberater.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Baufachberater</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M147,88 L108,88" stroke-width="5" stroke="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">BFB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Fachberater.j2
+++ b/symbols/THW_Personen_weiß/Fachberater.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fachberater</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M147,88 L108,88" stroke-width="5" stroke="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">THW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Flugleiter.j2
+++ b/symbols/THW_Personen_weiß/Flugleiter.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Flugleiter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M147,88 L108,88" stroke-width="5" stroke="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">FL</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer.j2t
+++ b/symbols/THW_Personen_weiß/Gruppenführer.j2t
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#FFFFFF" fill="#003399" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#FFFFFF" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_B.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_B.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer B</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_B_1.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_B_1.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer B 1</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B 1</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_B_2.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_B_2.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer B 2</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B 2</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Bel.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Bel.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Beleuchtung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Bel</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_BrB.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_BrB.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Brückenbau</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">BrB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_E.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_E.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Elektroversorgung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">E</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_F.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_F.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Fernmeldegruppe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">F</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_I.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_I.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Infrastruktur</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">I</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_K.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_K.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">K</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Log-MW.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Log-MW.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Logistik-Materialwirtschaft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="136" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 22px;" fill="#FFFFFF">Log-MW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Log-V.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Log-V.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Logistik-Verpflegung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="137" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 26px;" fill="#FFFFFF">Log-V</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Ltr_FK.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Ltr_FK.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">FK</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_N.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_N.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Notversorgung und Notinstandsetzung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">N</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_O.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_O.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Ortung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">O</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_R.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_R.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Räumen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">R</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_SB.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_SB.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer schwere Bergung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">SB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Sp.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Sp.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Sprengen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Sp</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_TW.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_TW.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Trinkwasser</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="150" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">TW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_W.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_W.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Wassergefahren</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">W</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_WP.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_WP.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Wasserschaden-Pumpen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="150" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">WP</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Gruppenführer_Öl.j2
+++ b/symbols/THW_Personen_weiß/Gruppenführer_Öl.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Gruppenführer Ölschaden</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Öl</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer.j2
+++ b/symbols/THW_Personen_weiß/Helfer.j2
@@ -1,0 +1,11 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Helfer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_Fm.j2
+++ b/symbols/THW_Personen_weiß/Helfer_Fm.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fernmelder</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Fm</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_FmFü.j2
+++ b/symbols/THW_Personen_weiß/Helfer_FmFü.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Fernmeldeführer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="138" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">FmFü</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_IuK.j2
+++ b/symbols/THW_Personen_weiß/Helfer_IuK.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Helfer Information und Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="143" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 44px;" fill="#FFFFFF">IuK</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_Kf.j2
+++ b/symbols/THW_Personen_weiß/Helfer_Kf.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Kraftfahrer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Kf</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_Peer.j2
+++ b/symbols/THW_Personen_weiß/Helfer_Peer.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Peer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">Peer</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_RiFu.j2
+++ b/symbols/THW_Personen_weiß/Helfer_RiFu.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Richtfunker</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="138" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">RiFu</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_SGL.j2
+++ b/symbols/THW_Personen_weiß/Helfer_SGL.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebietsleiter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 37px;" fill="#003399">SGL</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Helfer_psFK.j2
+++ b/symbols/THW_Personen_weiß/Helfer_psFK.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Psychosoziale Fachkraft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">psFK</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_AB.j2
+++ b/symbols/THW_Personen_weiß/Stab_AB.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Ausbildungsbeauftragter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">AB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_BÖH.j2
+++ b/symbols/THW_Personen_weiß/Stab_BÖH.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Beauftragter für Öffentlichkeitsarbeit und Helferwerbung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">BÖH</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_Ko.j2
+++ b/symbols/THW_Personen_weiß/Stab_Ko.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Koch</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Ko</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_OB.j2
+++ b/symbols/THW_Personen_weiß/Stab_OB.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Ortsbeauftragter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">OB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_OJB.j2
+++ b/symbols/THW_Personen_weiß/Stab_OJB.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Ortsjugendbetreuer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">OJB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S1.j2
+++ b/symbols/THW_Personen_weiß/Stab_S1.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 1 - Personal und innerer Dienst</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S1</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S2.j2
+++ b/symbols/THW_Personen_weiß/Stab_S2.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 2 - Lage</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S2</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S3.j2
+++ b/symbols/THW_Personen_weiß/Stab_S3.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 3 - Einsatz</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S3</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S4.j2
+++ b/symbols/THW_Personen_weiß/Stab_S4.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 4 - Versorgung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S4</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S5.j2
+++ b/symbols/THW_Personen_weiß/Stab_S5.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 5 - Presse- und Medienarbeit</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S5</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_S6.j2
+++ b/symbols/THW_Personen_weiß/Stab_S6.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Sachgebiet 6 - Informations- und Kommunikationswesen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">S6</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_SM.j2
+++ b/symbols/THW_Personen_weiß/Stab_SM.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Schirrmeister</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">SM</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_Stv_OB.j2
+++ b/symbols/THW_Personen_weiß/Stab_Stv_OB.j2
@@ -1,0 +1,13 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Stellvertretender Ortsbeauftragter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">StvOB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Stab_Vw.j2
+++ b/symbols/THW_Personen_weiß/Stab_Vw.j2
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Verwaltungsbeauftragter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Vw</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_B.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_B.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Bergung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_B_1.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_B_1.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer B 1</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B 1</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_B_2.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_B_2.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer B 2</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">B 2</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_BrB.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_BrB.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Brückenbau</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">BrB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_E.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_E.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Elektroversorgung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">E</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_ESS.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_ESS.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Einsatzstellen-Sicherungssystem</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">ESS</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_F.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_F.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Führung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">F</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Fm.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Fm.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Fernmeldetrupp</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Fm</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_FüGeh.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_FüGeh.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Führungsgehilfe</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 24px;" fill="#003399">FüGeh</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_I.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_I.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Infrastruktur</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">I</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_K.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_K.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">K</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_LdF.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_LdF.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer - Leiter des Fernmeldebetriebs</title> 
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">LdF</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Log-M.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Log-M.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Logistik-Materialwirtschaft</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">Log-M</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Log-V.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Log-V.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Logistik-Verpflegung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 28px;" fill="#003399">Log-V</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Log-VG.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Log-VG.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Logistik-Verbrauchsgüter</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="137" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 24px;" fill="#003399">Log-VG</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_MHP.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_MHP.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer mobiler Hochwasserpegel</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="140" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 32px;" fill="#003399">MHP</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_N.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_N.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Notversorgung und Notinstandsetzung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">N</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_O.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_O.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Ortung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">O</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_R.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_R.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Räumen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">R</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_SB.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_SB.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer schwere Bergung</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">SB</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Sp.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Sp.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Sprengen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Sp</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_TS.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_TS.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer schwerer Transport</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">TS</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_TW.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_TW.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Trinkwasser</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="150" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">TW</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_UL.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_UL.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Unbemannte Luftfahrzeuge</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">UL</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_W.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_W.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Wassergefahren</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">W</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_WP.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_WP.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Wasserschaden-Pumpen</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="150" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">WP</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Truppführer_Öl.j2
+++ b/symbols/THW_Personen_weiß/Truppführer_Öl.j2
@@ -1,0 +1,14 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Truppführer Ölschaden</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">Öl</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugführer_FZ_FK.j2
+++ b/symbols/THW_Personen_weiß/Zugführer_FZ_FK.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugführer Fachzug Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">FK</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugführer_FZ_Log.j2
+++ b/symbols/THW_Personen_weiß/Zugführer_FZ_Log.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugführer Fachzug Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="143" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">Log</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugführer_TZ.j2
+++ b/symbols/THW_Personen_weiß/Zugführer_TZ.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugführer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+
+	<ellipse cx="100" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="156" cy="44" rx="10" ry="10" fill="#000000" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">TZ</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugtruppführer_FZ_FK.j2
+++ b/symbols/THW_Personen_weiß/Zugtruppführer_FZ_FK.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtruppführer Fachzug Führung-Kommunikation</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="114" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="128" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="142" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">FK</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugtruppführer_FZ_Log.j2
+++ b/symbols/THW_Personen_weiß/Zugtruppführer_FZ_Log.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtruppführer Fachzug Logistik</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="114" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="128" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="142" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="143" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 40px;" fill="#003399">Log</text>
+</svg>

--- a/symbols/THW_Personen_weiß/Zugtruppführer_TZ.j2
+++ b/symbols/THW_Personen_weiß/Zugtruppführer_TZ.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewbox="0 0 256 256">
+	<title>Zugtruppführer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+	</defs>
+	<path d="M69,128 L128,69 L187,128 L128,187 Z" stroke-width="5" stroke="#003399" fill="#FFFFFF" />
+	<path d="M128,64 L152,88 L104,88 Z" stroke-width="0" fill="#003399" />
+	<ellipse cx="128" cy="44" rx="10" ry="10" fill="#000000" />
+	<ellipse cx="114" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="128" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<ellipse cx="142" cy="100" rx="5" ry="5" fill="#FFFFFF" />
+	<path d="M64,128 L128,64 L192,128 L128,192 Z" stroke-width="2" stroke="#000000" fill="none" />
+	<text x="128" y="145" style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px;" fill="#003399">TZ</text>
+</svg>


### PR DESCRIPTION
Für farb- und kostensparende Ausdrucke der takt. Zeichen. Weiterhin kann weißer Hintergrund (u.a. bei der Arbeit in FüSt) von Vorteil sein.