### PR TITLE
Behebt Issue 185: direkte Farbanweisungen in THW_Fahrzeugen durch Verweise ersetzt

### DIFF
--- a/symbols/THW_Fahrzeuge/Abrollbehälter_Container.j2
+++ b/symbols/THW_Fahrzeuge/Abrollbehälter_Container.j2
@@ -14,6 +14,6 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Abrollbehälter_Mulde.j2
+++ b/symbols/THW_Fahrzeuge/Abrollbehälter_Mulde.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Mulde</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Abrollbehälter_Plattform.j2
+++ b/symbols/THW_Fahrzeuge/Abrollbehälter_Plattform.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Pf</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Abrollbehälter_TH.j2
+++ b/symbols/THW_Fahrzeuge/Abrollbehälter_TH.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">TH</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_EGS.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_EGS.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+	<title>Anhänger Einsatzgerüstsystem</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
+	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
+	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
+	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">EGS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_NEA_200kVA.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_NEA_200kVA.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">NEA</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">200 kVA</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">200 kVA</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_NEA_50kVA_LiMa.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_NEA_50kVA_LiMa.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">NEA</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">50 kVA LiMa</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">50 kVA LiMa</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_NEA_650kVA.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_NEA_650kVA.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">NEA</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">650 kVA</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">650 kVA</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_O_A_2t.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_O_A_2t.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">O 2 t</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">A</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">A</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_O_B_2t.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_O_B_2t.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">O 2 t</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">B</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">B</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_SwPu_15000.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_SwPu_15000.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">SwPu</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">15.000 l/min</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">15.000 l/min</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_SwPu_25000.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_SwPu_25000.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">SwPu</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">25.000 l/min</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">25.000 l/min</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Anhänger_SwPu_5000.j2
+++ b/symbols/THW_Fahrzeuge/Anhänger_SwPu_5000.j2
@@ -14,6 +14,6 @@
 	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
 	<path d="M10,121 L10,121.5 L0,121.5 M0,136.5 L10,136.5 L10,137" stroke="{{ thw.colorStroke }}" stroke-width="1" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">SwPu</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">5.000 l/min</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">5.000 l/min</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_10ft.j2
+++ b/symbols/THW_Fahrzeuge/Container_10ft.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">ISO 10ft</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_20ft.j2
+++ b/symbols/THW_Fahrzeuge/Container_20ft.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">ISO 20ft</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_BDF.j2
+++ b/symbols/THW_Fahrzeuge/Container_BDF.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">BDF</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_EGS.j2
+++ b/symbols/THW_Fahrzeuge/Container_EGS.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">EGS</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_WB.j2
+++ b/symbols/THW_Fahrzeuge/Container_WB.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">WB</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Container_Werkstatt.j2
+++ b/symbols/THW_Fahrzeuge/Container_Werkstatt.j2
@@ -14,7 +14,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="#000000" fill="none" stroke-width="5" clip-path="url(#hook)" />
+	<ellipse cx="8" cy="80" rx="5" ry="5" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" clip-path="url(#hook)" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Wks</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Gabelstapler_2t.j2
+++ b/symbols/THW_Fahrzeuge/Gabelstapler_2t.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Stapler</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">2 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">2 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Gabelstapler_3t.j2
+++ b/symbols/THW_Fahrzeuge/Gabelstapler_3t.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Stapler</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">3 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">3 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_9t.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_9t.j2
@@ -15,6 +15,6 @@
 	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">9 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">9 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_9t_nicht_geländegängig.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_9t_nicht_geländegängig.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">9 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">9 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_Lkr.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_Lkr.j2
@@ -15,6 +15,6 @@
 	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">LKr</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">LKr</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_Lkr_1_5t.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_Lkr_1_5t.j2
@@ -15,6 +15,6 @@
 	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">LKr 1,5 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">LKr 1,5 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_Lkr_1_5t_nicht_geländegängig.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_Lkr_1_5t_nicht_geländegängig.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">LKr 1,5 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">LKr 1,5 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_K_Lkr_nicht_geländegängig.j2
+++ b/symbols/THW_Fahrzeuge/LKW_K_Lkr_nicht_geländegängig.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-K</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">LKr</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">LKr</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_Lbw_7t.j2
+++ b/symbols/THW_Fahrzeuge/LKW_Lbw_7t.j2
@@ -15,6 +15,6 @@
 	<ellipse cx="128" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-Lbw</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">7 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">7 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/LKW_Lbw_7t_nicht_geländegängig.j2
+++ b/symbols/THW_Fahrzeuge/LKW_Lbw_7t_nicht_geländegängig.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">LKW-Lbw</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">7 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">7 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Sattelzugmaschine.j2
+++ b/symbols/THW_Fahrzeuge/Sattelzugmaschine.j2
@@ -11,7 +11,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
 	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5"  />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">SZM</text>

--- a/symbols/THW_Fahrzeuge/Teleskoplader.j2
+++ b/symbols/THW_Fahrzeuge/Teleskoplader.j2
@@ -14,6 +14,6 @@
 	<ellipse cx="40" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="210" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">Telelader</text>
-    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="#FFFFFF" x="20" y="180">2 t</text>
+    <text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: start; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="20" y="180">2 t</text>
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
 </svg>

--- a/symbols/THW_Fahrzeuge/Wechselbrücke.j2
+++ b/symbols/THW_Fahrzeuge/Wechselbrücke.j2
@@ -1,0 +1,17 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+	<title>Wechselbrücke</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
+	<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
+	<path d="M12,63 L12,199 L256,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
+	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge/Wechselbrücke_EGS.j2
+++ b/symbols/THW_Fahrzeuge/Wechselbrücke_EGS.j2
@@ -1,0 +1,18 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+	<title>Wechselbrücke EGS</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" />
+		</clipPath>
+	</defs>
+	<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
+	<path d="M19,64 L19,192 L255,192 L255,64 Q137,100 19,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
+	<path d="M12,63 L12,199 L256,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
+	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">EGS</text>
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge/Wechselbrücke_leer.j2
+++ b/symbols/THW_Fahrzeuge/Wechselbrücke_leer.j2
@@ -1,0 +1,15 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+	<title>Wechselbrücke leer</title>
+	<defs>
+		<style type="text/css">
+		{% include './fonts/fonts.j2' %}
+		</style>
+		<clipPath id="symbol">
+			<path d="M12,63 L12,199 L256,199" />
+		</clipPath>
+	</defs>
+	<path d="M12,63 L12,199 L256,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
+	<rect x="0" y="121.5" width="11" height="15" fill="{{ thw.colorSecondary }}" />
+	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: end; font-size: 16px;" fill="{{ thw.colorSecondary }}" x="236" y="180">THW</text>
+</svg>

--- a/symbols/THW_Fahrzeuge/Wechselladerfahrzeug.j2
+++ b/symbols/THW_Fahrzeuge/Wechselladerfahrzeug.j2
@@ -11,7 +11,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
 	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="128" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5"  />
 	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5"  />

--- a/symbols/THW_Fahrzeuge/Wechselladerfahrzeug_mit_Ladekran.j2
+++ b/symbols/THW_Fahrzeuge/Wechselladerfahrzeug_mit_Ladekran.j2
@@ -11,7 +11,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
 	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5"  />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">WLF Lkr</text>

--- a/symbols/THW_Fahrzeuge/Wechselladerfahrzeug_nicht_geländegängig.j2
+++ b/symbols/THW_Fahrzeuge/Wechselladerfahrzeug_nicht_geländegängig.j2
@@ -11,7 +11,7 @@
 	</defs>
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="{{ thw.colorPrimary }}" stroke-width="10" stroke="{{ thw.colorSecondary }}" clip-path="url(#symbol)" />
 	<path d="M10,64 L10,192 L246,192 L246,64 Q128,100 10,64 Z" fill="none" stroke-width="1" stroke="{{ thw.colorStroke }}" />
-	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="#000000" />
+	<path d="M3,63 L3,199 L247,199" fill="none" stroke-width="5" stroke="{{ thw.colorStroke }}" />
 	<ellipse cx="40" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5" />
 	<ellipse cx="216" cy="209" rx="10" ry="10" stroke="{{ thw.colorStroke }}" fill="none" stroke-width="5"  />
 	<text style="font-family: 'Roboto Slab'; font-weight: bold; text-anchor: middle; font-size: 48px; " fill="{{  thw.colorSecondary }}" x="128" y="145">WLF</text>


### PR DESCRIPTION
Ausschließlich auf die THW_Fahrzeuge angwandt:

strokes und fills mit festen Farbzuweisungen wie z.B. #FFFFFF oder #000000 durch entsprechende Verweise thw.colorStroke bzw. thw.colorSecondary ersetzt.