### PR TITLE
Maßnahme Brandbekämpfung mit Linien statt Pfad

### DIFF
--- a/symbols/Maßnahmen/Brandbekämpfung.j2
+++ b/symbols/Maßnahmen/Brandbekämpfung.j2
@@ -3,5 +3,7 @@
 	<title>Brandbekämpfung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<path d="M80 165 L165 165 M135 165 L165 145 M135 165 L165 185" stroke="#000000" stroke-width="3" fill="none" />
+	<line x1="80" y1="165" x2="165" y2="165" stroke="#000000" stroke-width="3" />
+	<line x1="135" y1="165" x2="165" y2="145" stroke="#000000" stroke-width="3" />
+	<line x1="135" y1="165" x2="165" y2="185" stroke="#000000" stroke-width="3" />
 </svg>

--- a/symbols/Maßnahmen/Elektroversorgung.j2
+++ b/symbols/Maßnahmen/Elektroversorgung.j2
@@ -1,6 +1,0 @@
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
-	<title>Maßnahme</title>
-	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
-	<path d="M128 128 m-2 -40 l10 0 l-15 35 l30 -10 l-25 55 l15 -5 l-20 15 l-5 -20 l7 9 l15 -40 l-30 10z" stroke="none" fill="#000000" />
-</svg>


### PR DESCRIPTION
Hier dann mal das Symbol Maßnahme Brandbekämpfung mit einzelnen Linien.

Ich hatte den Path aus einem Feuerwehrzeichen kopiert, so ist es aber definitiv schöner zu lesen.