### PR TITLE
Maßnahme Wasserrettung korrigiert

### DIFF
--- a/symbols/Maßnahmen/Wasserrettung.j2
+++ b/symbols/Maßnahmen/Wasserrettung.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Wasserrettung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 

--- a/symbols/Maßnahmen/Wasserrettung.j2
+++ b/symbols/Maßnahmen/Wasserrettung.j2
@@ -3,8 +3,7 @@
 	<title>Wasserrettung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<path d="M128,145 l36,0 a18,18 180 1 1 -36,0 z" stroke-width="3" stroke="#000000" fill="none" />
-	<path d="M95,140 a5,5 180 1 1 10,0 a5,5 180 1 0 10,0" stroke-width="2" stroke="#003399" fill="none" />
-	<path d="M95,150 a5,5 180 1 1 10,0 a5,5 180 1 0 10,0" stroke-width="2" stroke="#003399" fill="none" />
-	<path d="M95,160 a5,5 180 1 1 10,0 a5,5 180 1 0 10,0" stroke-width="2" stroke="#003399" fill="none" />
+	<path d="M128 142 l18 18 l-18 18 l-18 -18 l18 -18 Z" stroke-width="4" stroke="#000000" fill="none" />
+	<path d="M103 134 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="4" />
+	<path d="M103 122 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="4" />
 </svg>

--- a/symbols/Maßnahmen/Wasserrettung.j2
+++ b/symbols/Maßnahmen/Wasserrettung.j2
@@ -1,9 +1,9 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
 	<title>Wasserrettung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<path d="M128 142 l18 18 l-18 18 l-18 -18 l18 -18 Z" stroke-width="4" stroke="#000000" fill="none" />
-	<path d="M103 134 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="4" />
-	<path d="M103 122 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="4" />
+	<path d="M103 126 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M103 136 c 5,0 5,-9 12,-9 6,0 6,9 12,9 6,0 6,-9 12,-9 7,0 7,9 12,9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M128 142 l18 18 l-18 18 l-18 -18 l18 -18 Z" stroke-width="3" stroke="#000000" fill="none" />
 </svg>


### PR DESCRIPTION
Das bisherige Zeichen war Unsinn, hier wurde eine Andeutung der Maßnahme „Einsatz von Wasserfahrzeugen“ gezeigt. Das war aber weder vollständig, noch ist es das korrekte Zeichen für die Wasserrettung.

Hier ist jetzt ein Vorschlag zur Korrektur.