### PR TITLE
Maßnahme Technische_Hilfeleistung erzeugt

### DIFF
--- a/symbols/Maßnahmen/Technische_Hilfeleistung.j2
+++ b/symbols/Maßnahmen/Technische_Hilfeleistung.j2
@@ -1,5 +1,5 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Technische Hilfeleistung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 

--- a/symbols/Maßnahmen/Technische_Hilfeleistung.j2
+++ b/symbols/Maßnahmen/Technische_Hilfeleistung.j2
@@ -1,0 +1,11 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="160" height="160" viewBox="0 0 256 256">
+	<title>Technische Hilfeleistung</title>
+	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
+
+	<line x1="83" y1="160" x2="108" y2="170" stroke="#000000" stroke-width="3"/>
+	<line x1="83" y1="180" x2="108" y2="170" stroke="#000000" stroke-width="3"/>
+	<rect x="108" y="160" width="40" height="20" fill="none" stroke="#000000" stroke-width="3"/>
+	<path d="M148 163 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M148 171 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
+</svg>

--- a/symbols/Maßnahmen/Technische_Hilfeleistung.j2
+++ b/symbols/Maßnahmen/Technische_Hilfeleistung.j2
@@ -3,8 +3,8 @@
 	<title>Technische Hilfeleistung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<path d="M79.2 163 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
-	<path d="M79.2 171 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M79 163 c 7 0 7 9 14 9 7 0 7 -9 14 -9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M79 171 c 7 0 7 9 14 9 7 0 7 -9 14 -9" fill="none" stroke="#000000" stroke-width="3" />
 	<rect x="108" y="160" width="40" height="20" fill="none" stroke="#000000" stroke-width="3"/>
 	<line x1="173" y1="160" x2="148" y2="170" stroke="#000000" stroke-width="3"/>
 	<line x1="173" y1="180" x2="148" y2="170" stroke="#000000" stroke-width="3"/>

--- a/symbols/Maßnahmen/Technische_Hilfeleistung.j2
+++ b/symbols/Maßnahmen/Technische_Hilfeleistung.j2
@@ -3,9 +3,9 @@
 	<title>Technische Hilfeleistung</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<line x1="83" y1="160" x2="108" y2="170" stroke="#000000" stroke-width="3"/>
-	<line x1="83" y1="180" x2="108" y2="170" stroke="#000000" stroke-width="3"/>
+	<path d="M79.2 163 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
+	<path d="M79.2 171 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
 	<rect x="108" y="160" width="40" height="20" fill="none" stroke="#000000" stroke-width="3"/>
-	<path d="M148 163 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
-	<path d="M148 171 c 7.2 0 7.2 9 14.4 9 7.2 0 7.2 -9 14.4 -9" fill="none" stroke="#000000" stroke-width="3" />
+	<line x1="173" y1="160" x2="148" y2="170" stroke="#000000" stroke-width="3"/>
+	<line x1="173" y1="180" x2="148" y2="170" stroke="#000000" stroke-width="3"/>
 </svg>


### PR DESCRIPTION
Nun hier die „Ente“ für die technische Hilfeleistung. Während des Bauens dieses Zeichens ist mir aufgefallen, dass es wohl eher eine hydraulische Schere symbolisieren soll.

Sag Bescheid, ob du noch Änderungen wünschst. Ich freue mich über Aktivität im Upstream :)