### PR TITLE
Maßnahme Dekontaminieren: Stroke-Dicke 8→4, Kreise statt Ellipsen

### DIFF
--- a/symbols/Maßnahmen/Dekontaminieren.j2
+++ b/symbols/Maßnahmen/Dekontaminieren.j2
@@ -2,7 +2,7 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Dekontaminieren</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
-	<path d="M104,128 l50,50 M152,128 l-50,50" stroke-width="8" stroke="#000000" fill="none" />
+	<path d="M104,128 l50,50 M152,128 l-50,50" stroke-width="5" stroke="#000000" fill="none" />
 	<path d="M108,182 L98,182 L98,172 Z" fill="#000000" />
 	<path d="M148,182 L158,182 L158,172 Z" fill="#000000" />
 	<ellipse cx="104" cy="134" rx="10" ry="10" fill="#000000" />

--- a/symbols/Maßnahmen/Dekontaminieren.j2
+++ b/symbols/Maßnahmen/Dekontaminieren.j2
@@ -2,9 +2,10 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256">
 	<title>Dekontaminieren</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
-	<path d="M104,128 l50,50 M152,128 l-50,50" stroke-width="5" stroke="#000000" fill="none" />
+
+	<circle cx="104" cy="134" r="10" fill="#000000" />
+	<circle cx="152" cy="134" r="10" fill="#000000" />
+	<path d="M104,128 l50,50 M152,128 l-50,50" stroke-width="4" stroke="#000000" fill="none" />
 	<path d="M108,182 L98,182 L98,172 Z" fill="#000000" />
 	<path d="M148,182 L158,182 L158,172 Z" fill="#000000" />
-	<ellipse cx="104" cy="134" rx="10" ry="10" fill="#000000" />
-	<ellipse cx="152" cy="134" rx="10" ry="10" fill="#000000" />
 </svg>


### PR DESCRIPTION
Linien schmaler gemacht, sieht so schöner aus imho.