### PR TITLE
Maßnahme Beleuchtung: Kreis statt Ellipse

### DIFF
--- a/symbols/Maßnahmen/Beleuchten.j2
+++ b/symbols/Maßnahmen/Beleuchten.j2
@@ -3,6 +3,6 @@
 	<title>Beleuchten</title>
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
-	<path d="M113,180 l0,-60 a15,15 180 1 1 30,0" stroke-width="3" stroke="#000000" fill="none" />
+	<path d="M113,180 l0,-60 a15,15 180 1,1 30,0" stroke-width="3" stroke="#000000" fill="none" />
 	<circle cx="143" cy="125" r="5" stroke-width="3" stroke="#000000" fill="none" />
 </svg>

--- a/symbols/Maßnahmen/Beleuchten.j2
+++ b/symbols/Maßnahmen/Beleuchten.j2
@@ -4,5 +4,5 @@
 	<path d="M50,192 L128,64 L206,192 Z" stroke-width="5" stroke="#000000" fill="none" />
 
 	<path d="M113,180 l0,-60 a15,15 180 1 1 30,0" stroke-width="3" stroke="#000000" fill="none" />
-	<ellipse cx="143" cy="125" rx="5" ry="5" stroke-width="3" stroke="#000000" fill="none" />
+	<circle cx="143" cy="125" r="5" stroke-width="3" stroke="#000000" fill="none" />
 </svg>


### PR DESCRIPTION
Vereinfacht die gleichförmige Ellipse zu einem Kreis. Vereinfacht den Code, das Element sieht identisch aus.